### PR TITLE
Update UnrealBody.uplugin to support Android

### DIFF
--- a/UnrealBody.uplugin
+++ b/UnrealBody.uplugin
@@ -20,7 +20,7 @@
 			"Name" : "UnrealBody",
 			"Type" : "Runtime",
 			"LoadingPhase" : "PostConfigInit",
-			"WhitelistPlatforms" : [ "Win64" ]
+			"WhitelistPlatforms" : [ "Win64","Android" ]
 		}
 	]
 }


### PR DESCRIPTION
For those trying to compile on a VR headset like a Quest, the Android platform should be supported